### PR TITLE
feat/test factories

### DIFF
--- a/src/Database/Factories/ShopFactory.php
+++ b/src/Database/Factories/ShopFactory.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Esign\LaravelShopify\Database\Factories;
+
+use Esign\LaravelShopify\Models\Shop;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class ShopFactory extends Factory
+{
+    protected $model = Shop::class;
+
+    public function definition(): array
+    {
+        return [
+            'domain' => $this->faker->unique()->slug() . '.myshopify.com',
+            'access_token' => 'shpat_' . $this->faker->sha1(),
+            'installed_at' => now(),
+        ];
+    }
+}

--- a/src/Models/Shop.php
+++ b/src/Models/Shop.php
@@ -138,5 +138,4 @@ class Shop extends Authenticatable
             'user' => null, // Offline tokens don't have user
         ];
     }
-
 }

--- a/src/Models/Shop.php
+++ b/src/Models/Shop.php
@@ -2,11 +2,14 @@
 
 namespace Esign\LaravelShopify\Models;
 
+use Esign\LaravelShopify\Database\Factories\ShopFactory;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 
 class Shop extends Authenticatable
 {
+    use HasFactory;
     use SoftDeletes;
 
     protected $fillable = [
@@ -132,5 +135,10 @@ class Shop extends Authenticatable
             'refreshTokenExpires' => $this->refresh_token_expires_at?->toIso8601String(),
             'user' => null, // Offline tokens don't have user
         ];
+    }
+
+    protected static function newFactory(): ShopFactory
+    {
+        return ShopFactory::new();
     }
 }

--- a/src/Models/Shop.php
+++ b/src/Models/Shop.php
@@ -2,7 +2,6 @@
 
 namespace Esign\LaravelShopify\Models;
 
-use Esign\LaravelShopify\Database\Factories\ShopFactory;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
@@ -137,8 +136,4 @@ class Shop extends Authenticatable
         ];
     }
 
-    protected static function newFactory(): ShopFactory
-    {
-        return ShopFactory::new();
-    }
 }

--- a/src/Models/Shop.php
+++ b/src/Models/Shop.php
@@ -2,10 +2,13 @@
 
 namespace Esign\LaravelShopify\Models;
 
+use Esign\LaravelShopify\Database\Factories\ShopFactory;
+use Illuminate\Database\Eloquent\Attributes\UseFactory;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 
+#[UseFactory(ShopFactory::class)]
 class Shop extends Authenticatable
 {
     use HasFactory;

--- a/tests/Feature/Console/DecryptTokensCommandTest.php
+++ b/tests/Feature/Console/DecryptTokensCommandTest.php
@@ -15,15 +15,13 @@ class DecryptTokensCommandTest extends TestCase
         $plainAccessToken = 'shpat_test_token_123';
         $plainRefreshToken = 'refresh_token_456';
 
-        $shop = Shop::create([
-            'domain' => 'test-shop.myshopify.com',
+        $shop = Shop::factory()->create([
             'access_token' => encrypt($plainAccessToken),
             'refresh_token' => encrypt($plainRefreshToken),
-            'installed_at' => now(),
         ]);
 
         // Verify tokens are encrypted in database
-        $rawShop = DB::table('shops')->where('id', $shop->id)->first();
+        $rawShop = DB::table('shops')->where('id', $shop->getKey())->first();
         $this->assertNotEquals($plainAccessToken, $rawShop->access_token);
         $this->assertNotEquals($plainRefreshToken, $rawShop->refresh_token);
 
@@ -32,7 +30,7 @@ class DecryptTokensCommandTest extends TestCase
             ->assertSuccessful();
 
         // Verify tokens are now plain text in database
-        $rawShop = DB::table('shops')->where('id', $shop->id)->first();
+        $rawShop = DB::table('shops')->where('id', $shop->getKey())->first();
         $this->assertEquals($plainAccessToken, $rawShop->access_token);
         $this->assertEquals($plainRefreshToken, $rawShop->refresh_token);
     }
@@ -42,7 +40,6 @@ class DecryptTokensCommandTest extends TestCase
     {
         // Create a shop with plain text tokens
         $shop = $this->createShop([
-            'domain' => 'test-shop.myshopify.com',
             'access_token' => 'shpat_plain_token',
             'refresh_token' => 'refresh_plain_token',
         ]);
@@ -51,7 +48,7 @@ class DecryptTokensCommandTest extends TestCase
             ->assertSuccessful();
 
         // Verify tokens remain unchanged
-        $rawShop = DB::table('shops')->where('id', $shop->id)->first();
+        $rawShop = DB::table('shops')->where('id', $shop->getKey())->first();
         $this->assertEquals('shpat_plain_token', $rawShop->access_token);
         $this->assertEquals('refresh_plain_token', $rawShop->refresh_token);
     }
@@ -61,7 +58,6 @@ class DecryptTokensCommandTest extends TestCase
     {
         // Create a shop with null tokens
         $this->createShop([
-            'domain' => 'test-shop.myshopify.com',
             'access_token' => null,
             'refresh_token' => null,
         ]);
@@ -74,10 +70,8 @@ class DecryptTokensCommandTest extends TestCase
     public function it_requires_confirmation_without_force_flag()
     {
         // Create a shop with encrypted token
-        Shop::create([
-            'domain' => 'test-shop.myshopify.com',
+        Shop::factory()->create([
             'access_token' => encrypt('shpat_token'),
-            'installed_at' => now(),
         ]);
 
         // Without force flag, should ask for confirmation
@@ -93,10 +87,8 @@ class DecryptTokensCommandTest extends TestCase
         $plainToken = 'shpat_test_token';
         $encryptedToken = encrypt($plainToken);
 
-        $shop = Shop::create([
-            'domain' => 'test-shop.myshopify.com',
+        $shop = Shop::factory()->create([
             'access_token' => $encryptedToken,
-            'installed_at' => now(),
         ]);
 
         // Run in dry-run mode
@@ -104,7 +96,7 @@ class DecryptTokensCommandTest extends TestCase
             ->assertSuccessful();
 
         // Verify token is still encrypted
-        $rawShop = DB::table('shops')->where('id', $shop->id)->first();
+        $rawShop = DB::table('shops')->where('id', $shop->getKey())->first();
         $this->assertEquals($encryptedToken, $rawShop->access_token);
     }
 
@@ -160,16 +152,12 @@ class DecryptTokensCommandTest extends TestCase
     public function it_provides_accurate_summary_statistics()
     {
         // Create mix of encrypted and plain text tokens
-        Shop::create([
-            'domain' => 'encrypted-shop.myshopify.com',
+        Shop::factory()->create([
             'access_token' => encrypt('shpat_encrypted'),
-            'installed_at' => now(),
         ]);
 
-        Shop::create([
-            'domain' => 'plain-shop.myshopify.com',
+        Shop::factory()->create([
             'access_token' => 'shpat_plain',
-            'installed_at' => now(),
         ]);
 
         $this->artisan('shopify:decrypt-tokens', ['--force' => true])
@@ -184,10 +172,8 @@ class DecryptTokensCommandTest extends TestCase
     {
         // Create multiple shops with encrypted tokens
         for ($i = 1; $i <= 5; $i++) {
-            Shop::create([
-                'domain' => "shop{$i}.myshopify.com",
+            Shop::factory()->create([
                 'access_token' => encrypt("shpat_token_{$i}"),
-                'installed_at' => now(),
             ]);
         }
 
@@ -207,10 +193,8 @@ class DecryptTokensCommandTest extends TestCase
         // Create a shop with Laravel-encrypted token
         $encryptedToken = encrypt('shpat_test');
 
-        Shop::create([
-            'domain' => 'test-shop.myshopify.com',
+        Shop::factory()->create([
             'access_token' => $encryptedToken,
-            'installed_at' => now(),
         ]);
 
         $this->artisan('shopify:decrypt-tokens', ['--dry-run' => true])

--- a/tests/Feature/ShopSoftDeleteTest.php
+++ b/tests/Feature/ShopSoftDeleteTest.php
@@ -86,7 +86,7 @@ class ShopSoftDeleteTest extends TestCase
     public function it_permanently_deletes_shop_with_force_delete()
     {
         $shop = $this->createShop(['domain' => 'test.myshopify.com']);
-        $shopId = $shop->id;
+        $shopId = $shop->getKey();
 
         $shop->markAsUninstalled();
         $shop->forceDelete();

--- a/tests/Feature/WebhookDispatchTest.php
+++ b/tests/Feature/WebhookDispatchTest.php
@@ -55,7 +55,7 @@ class WebhookDispatchTest extends TestCase
         $shop = $this->createShop();
         $this->assertTrue($shop->isInstalled());
 
-        $payload = json_encode(['id' => $shop->id]);
+        $payload = json_encode(['id' => $shop->getKey()]);
 
         config(['shopify.webhooks.routes' => [
             'app/uninstalled' => [

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -48,11 +48,7 @@ abstract class TestCase extends Orchestra
      */
     protected function createShop(array $attributes = []): \Esign\LaravelShopify\Models\Shop
     {
-        return \Esign\LaravelShopify\Models\Shop::create(array_merge([
-            'domain' => 'test-shop.myshopify.com',
-            'access_token' => 'shpat_test_token_'.bin2hex(random_bytes(16)),
-            'installed_at' => now(),
-        ], $attributes));
+        return \Esign\LaravelShopify\Models\Shop::factory()->create($attributes);
     }
 
     /**

--- a/tests/Unit/Jobs/AppUninstalledJobTest.php
+++ b/tests/Unit/Jobs/AppUninstalledJobTest.php
@@ -154,7 +154,7 @@ class AppUninstalledJobTest extends TestCase
             'domain' => 'test-shop.myshopify.com',
         ]);
 
-        $shopId = $shop->id;
+        $shopId = $shop->getKey();
         $originalDomain = $shop->domain;
 
         $job = new AppUninstalledJob(

--- a/tests/Unit/Jobs/ShopRedactJobTest.php
+++ b/tests/Unit/Jobs/ShopRedactJobTest.php
@@ -22,7 +22,7 @@ class ShopRedactJobTest extends TestCase
         $shop->deleted_at = now()->subHours(50);
         $shop->save();
 
-        $shopId = $shop->id;
+        $shopId = $shop->getKey();
 
         $job = new ShopRedactJob(
             shopDomain: 'test-shop.myshopify.com',
@@ -47,7 +47,7 @@ class ShopRedactJobTest extends TestCase
         Log::shouldReceive('info')->twice();
 
         $shop = $this->createShop(['domain' => 'test-shop.myshopify.com']);
-        $shopId = $shop->id;
+        $shopId = $shop->getKey();
 
         $this->assertFalse($shop->trashed());
 

--- a/tests/Unit/ShopModelExtendedTest.php
+++ b/tests/Unit/ShopModelExtendedTest.php
@@ -11,7 +11,6 @@ class ShopModelExtendedTest extends TestCase
     public function it_checks_if_refresh_token_is_expired()
     {
         $shop = $this->createShop([
-            'domain' => 'test-shop.myshopify.com',
             'refresh_token' => 'token',
             'refresh_token_expires_at' => now()->subDay(), // Expired
         ]);
@@ -23,7 +22,6 @@ class ShopModelExtendedTest extends TestCase
     public function it_returns_false_for_non_expired_refresh_token()
     {
         $shop = $this->createShop([
-            'domain' => 'test-shop.myshopify.com',
             'refresh_token' => 'token',
             'refresh_token_expires_at' => now()->addDays(30), // Not expired
         ]);
@@ -35,7 +33,6 @@ class ShopModelExtendedTest extends TestCase
     public function it_treats_null_refresh_token_expires_at_as_non_expiring()
     {
         $shop = $this->createShop([
-            'domain' => 'test-shop.myshopify.com',
             'refresh_token' => 'token',
             'refresh_token_expires_at' => null, // Non-expiring
         ]);
@@ -82,7 +79,6 @@ class ShopModelExtendedTest extends TestCase
     public function it_handles_null_tokens_in_token_array()
     {
         $shop = $this->createShop([
-            'domain' => 'test-shop.myshopify.com',
             'access_token' => null,
             'refresh_token' => null,
         ]);
@@ -120,7 +116,7 @@ class ShopModelExtendedTest extends TestCase
     /** @test */
     public function it_marks_shop_as_reinstalled_without_token()
     {
-        $shop = $this->createShop(['domain' => 'test-shop.myshopify.com']);
+        $shop = $this->createShop();
         $shop->delete(); // Soft delete
 
         $this->assertTrue($shop->trashed());
@@ -136,7 +132,6 @@ class ShopModelExtendedTest extends TestCase
     public function it_marks_shop_as_reinstalled_with_new_token()
     {
         $shop = $this->createShop([
-            'domain' => 'test-shop.myshopify.com',
             'access_token' => 'old_token',
         ]);
         $shop->delete();
@@ -153,15 +148,13 @@ class ShopModelExtendedTest extends TestCase
     {
         $plainRefreshToken = 'refresh_token_plain_text_123';
 
-        $shop = Shop::create([
-            'domain' => 'test-shop.myshopify.com',
+        $shop = Shop::factory()->create([
             'access_token' => 'shpat_test',
             'refresh_token' => $plainRefreshToken,
-            'installed_at' => now(),
         ]);
 
         // Token should be stored as plain text in database
-        $raw = $this->app['db']->table('shops')->where('id', $shop->id)->first();
+        $raw = $this->app['db']->table('shops')->where('id', $shop->getKey())->first();
         $this->assertEquals($plainRefreshToken, $raw->refresh_token);
 
         // And should be accessible as expected

--- a/tests/Unit/ShopModelTest.php
+++ b/tests/Unit/ShopModelTest.php
@@ -10,16 +10,14 @@ class ShopModelTest extends TestCase
     /** @test */
     public function it_creates_a_shop_with_required_attributes()
     {
-        $shop = Shop::create([
-            'domain' => 'test-shop.myshopify.com',
-            'access_token' => 'shpat_test_token',
-            'installed_at' => now(),
-        ]);
+        $shop = Shop::factory()->create();
 
         $this->assertDatabaseHas('shops', [
-            'domain' => 'test-shop.myshopify.com',
+            'id' => $shop->getKey(),
         ]);
 
+        $this->assertNotNull($shop->domain);
+        $this->assertNotNull($shop->access_token);
         $this->assertNotNull($shop->installed_at);
     }
 
@@ -28,14 +26,12 @@ class ShopModelTest extends TestCase
     {
         $plainToken = 'shpat_test_token_123';
 
-        $shop = Shop::create([
-            'domain' => 'test-shop.myshopify.com',
+        $shop = Shop::factory()->create([
             'access_token' => $plainToken,
-            'installed_at' => now(),
         ]);
 
         // Token should be stored as plain text in database
-        $raw = $this->app['db']->table('shops')->where('id', $shop->id)->first();
+        $raw = $this->app['db']->table('shops')->where('id', $shop->getKey())->first();
         $this->assertEquals($plainToken, $raw->access_token);
 
         // And should be accessible as expected
@@ -49,7 +45,7 @@ class ShopModelTest extends TestCase
 
         $shop->markAsUninstalled();
 
-        $this->assertSoftDeleted('shops', ['id' => $shop->id]);
+        $this->assertSoftDeleted('shops', ['id' => $shop->getKey()]);
         $this->assertNotNull($shop->fresh()?->uninstalled_at);
     }
 


### PR DESCRIPTION
**Add built-in Shop factory support and refactor tests to use factories**

- Factories toevoegen en tests omzetten naar gebruik van factories in plaats van handmatig aanmaken van records
- Package users kunnen gebruik maken van factories in hun test suites
- Gebruik van ->getKey() in plaats van ->id

We hebben ook een createShop() method misschien wordt die best gebruikt overal? Of juist niet aangezien het met factories niet zoveel meerwaarde biedt denk ik
